### PR TITLE
Potential fix for code scanning alert no. 51: Disabled TLS certificate check

### DIFF
--- a/rust/src/wns/resolver.rs
+++ b/rust/src/wns/resolver.rs
@@ -53,7 +53,6 @@ pub async fn resolve_handle_with_options(
         .unwrap_or_else(|| build_resolution_url(&local_part, &domain));
     let normalized = format!("{}.{}", local_part, domain);
     let client = Client::builder()
-        .danger_accept_invalid_certs(!options.verify_ssl)
         .timeout(std::time::Duration::from_secs_f64(options.timeout_seconds))
         .build()
         .map_err(|_| HandleResolutionError {


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/anp/security/code-scanning/51](https://github.com/agent-network-protocol/anp/security/code-scanning/51)

The safest fix is to stop calling `danger_accept_invalid_certs` with a value derived from runtime options. In reqwest, certificate verification is enabled by default, so the best non-breaking secure behavior is to always keep verification on and ignore any insecure toggle.

In `rust/src/wns/resolver.rs`, update the client builder in `resolve_handle_with_options` so it no longer calls:
- `.danger_accept_invalid_certs(!options.verify_ssl)`

and instead relies on default TLS verification (or explicitly sets `false`). This preserves existing functionality for normal secure operation, keeps timeout behavior unchanged, and removes the vulnerable sink. No new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
