### PR TITLE
Require explicit operation IDs for prekey bundle publication

### DIFF
--- a/docs/e2e/direct-e2ee-p5-sdk.md
+++ b/docs/e2e/direct-e2ee-p5-sdk.md
@@ -38,6 +38,7 @@ The SDK-owned boundary includes:
 P5 rules that product integrations rely on:
 
 - `prekey_bundle` must not embed `one_time_prekey`; OPK is a top-level sidecar from `direct.e2ee.get_prekey_bundle`.
+- A prekey-bundle publish `operation_id` identifies the complete publish payload, not only the stable `bundle_id`. Callers must reuse it when retrying the same payload and create a new one when the OPK sidecar changes.
 - Direct E2EE `direct.send` requires `operation_id == message_id`.
 - Current phase-1 direct-e2ee wire omits `params.auth` unless a future extension/capability explicitly changes that.
 - Direct init/cipher AAD uses JCS/RFC8785 and P5 `content_type` bindings.

--- a/rust/src/direct_e2ee/bundle.rs
+++ b/rust/src/direct_e2ee/bundle.rs
@@ -78,6 +78,7 @@ pub fn prekey_bundle_publish_request(
     local_service_did: &str,
     bundle: &PrekeyBundle,
     one_time_prekeys: &[OneTimePrekey],
+    operation_id: &str,
 ) -> Value {
     json!({
         "method": "direct.e2ee.publish_prekey_bundle",
@@ -91,7 +92,7 @@ pub fn prekey_bundle_publish_request(
                     "kind": "service",
                     "did": local_service_did,
                 },
-                "operation_id": format!("op-publish-{}", bundle.bundle_id),
+                "operation_id": operation_id,
             },
             "body": prekey_bundle_publish_body(bundle, one_time_prekeys),
         },
@@ -402,6 +403,7 @@ mod tests {
             "did:wba:b.example:services:message:e1_service",
             &bundle,
             &opks,
+            "op-publish-bundle-bob-001-opks-a1b2c3",
         );
 
         assert_eq!(
@@ -419,7 +421,7 @@ mod tests {
                     "kind": "service",
                     "did": "did:wba:b.example:services:message:e1_service",
                 },
-                "operation_id": "op-publish-bundle-bob-001",
+                "operation_id": "op-publish-bundle-bob-001-opks-a1b2c3",
             }))
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- require callers of the Rust prekey bundle publish helper to provide the `operation_id` explicitly
- separate stable `bundle_id` semantics from idempotency for the complete Bundle + OPK publish payload
- document that exact retries reuse an operation ID while a changed OPK sidecar uses a new one

## Rationale

A signed prekey Bundle remains stable while its top-level one-time-prekey sidecar may be replenished. Deriving the publish operation ID only from `bundle_id` therefore reuses one idempotency key for different request bodies and causes a valid replenishment to conflict.

## Compatibility

This intentionally changes the Rust helper signature. Product callers must provide an operation ID that identifies the complete publish payload. The wire protocol fields do not change.

## Validation

- `cargo test --manifest-path rust/Cargo.toml direct_e2ee --lib`
- 38 passed, 0 failed, 0 skipped