### PR TITLE
feat: add device manifests and MLS rejoin support

### DIFF
--- a/rust/src/group_e2ee/operations/v2.rs
+++ b/rust/src/group_e2ee/operations/v2.rs
@@ -3042,6 +3042,18 @@ fn process_welcome_with_scope(
         &input.request_id,
     )
     .map_err(GroupMlsOperationError::from)?;
+    let replace_removed_group = matches!(
+        binding_status(
+            &scope.app_conn,
+            &input.recipient_did,
+            &input.recipient_device_id,
+            &input.group_did,
+            &input.request_id,
+        )
+        .map_err(GroupMlsOperationError::from)?
+        .as_deref(),
+        Some("removed")
+    );
     if let Some(existing) = active_binding(
         &scope.app_conn,
         &input.recipient_did,
@@ -3084,16 +3096,24 @@ fn process_welcome_with_scope(
             .map_err(GroupMlsOperationError::from)?,
     )
     .map_err(|err| mls_operation_error("group.e2ee.welcome_invalid", err, &input.request_id))?;
-    let staged =
+    let mut join_builder =
         StagedWelcome::build_from_welcome(&scope.provider, &v2_group_join_config(), welcome)
             .map_err(|err| {
                 mls_operation_error("group.e2ee.welcome_invalid", err, &input.request_id)
             })?
-            .with_ratchet_tree(tree)
-            .build()
-            .map_err(|err| {
-                mls_operation_error("group.e2ee.welcome_invalid", err, &input.request_id)
-            })?;
+            .with_ratchet_tree(tree);
+    if replace_removed_group {
+        // A self-Remove keeps the authenticated prior epoch for audit and
+        // exclusion checks. A later owner-controlled Add uses a fresh
+        // KeyPackage and Welcome for the same MLS group id, so OpenMLS must
+        // replace that now-inactive local group instead of rejecting it as a
+        // duplicate. Active and other non-terminal bindings never take this
+        // path.
+        join_builder = join_builder.replace_old_group();
+    }
+    let staged = join_builder
+        .build()
+        .map_err(|err| mls_operation_error("group.e2ee.welcome_invalid", err, &input.request_id))?;
     if encode_b64u(staged.group_context().group_id().as_slice()) != input.crypto_group_id_b64u
         || staged.group_context().epoch().as_u64() != target_epoch
     {

--- a/rust/tests/group_e2ee_v2_operations.rs
+++ b/rust/tests/group_e2ee_v2_operations.rs
@@ -3146,15 +3146,88 @@ fn persistent_v2_operations_keep_same_did_devices_independent() {
     assert!(decrypt_v2(
         &a2_store,
         V2DecryptInput {
-            recipient_did: alice.did,
+            recipient_did: alice.did.clone(),
             recipient_device_id: a2_device.device_id.clone(),
             originating_meta: future_meta,
             group_cipher_object: future,
-            sender_did_document: owner.document,
+            sender_did_document: owner.document.clone(),
             now: NOW.to_owned(),
             draft_extension_negotiated: true,
             request_id: "req-decrypt-future-a2".to_owned(),
         },
     )
     .is_err());
+
+    let rejoin_a2_package = generate_key_package_v2(
+        &a2_store,
+        V2GenerateKeyPackageInput {
+            owner_did: alice.did.clone(),
+            owner_device_id: a2_device.device_id.clone(),
+            verification_method: a2_device.signing_key_id.clone(),
+            key_package_id: "kp-a2-rejoin".to_owned(),
+            issued_at: ISSUED_AT.to_owned(),
+            expires_at: EXPIRES_AT.to_owned(),
+            now: NOW.to_owned(),
+            draft_extension_negotiated: true,
+            request_id: "req-kp-a2-rejoin".to_owned(),
+        },
+        &alice.document,
+        &signing_key(a2_device),
+    )
+    .expect("removed A2 publishes a fresh rejoin KeyPackage");
+    let rejoin_a2 = add_member_prepare_v2(
+        &owner_store,
+        V2AddMemberInput {
+            meta: control_meta(&owner.did, &owner_device.device_id, "op-rejoin-a2"),
+            group_state_ref: state_ref(5),
+            group_key_package: rejoin_a2_package,
+            member_did_document: alice.document.clone(),
+            now: NOW.to_owned(),
+            draft_extension_negotiated: true,
+            pending_commit_id: "pending-rejoin-a2".to_owned(),
+            request_id: "req-rejoin-a2".to_owned(),
+        },
+    )
+    .expect("owner prepares A2 rejoin with the fresh KeyPackage");
+    force_pending_status(&owner_store, &rejoin_a2.pending_commit_id, "accepted");
+    finalize_commit_v2(
+        &owner_store,
+        V2FinalizeInput {
+            pending_commit_id: rejoin_a2.pending_commit_id,
+            request_id: "req-finalize-rejoin-a2".to_owned(),
+        },
+    )
+    .expect("owner finalizes A2 rejoin");
+    process_welcome_v2(
+        &a2_store,
+        V2ProcessWelcomeInput {
+            recipient_did: alice.did.clone(),
+            recipient_device_id: a2_device.device_id.clone(),
+            group_did: GROUP_DID.to_owned(),
+            group_state_ref: rejoin_a2.body.group_state_ref,
+            crypto_group_id_b64u: rejoin_a2.body.crypto_group_id_b64u,
+            epoch: rejoin_a2.body.epoch,
+            welcome_b64u: rejoin_a2.body.welcome_b64u,
+            ratchet_tree_b64u: rejoin_a2.body.ratchet_tree_b64u,
+            member_documents: member_documents(&owner, &alice),
+            now: NOW.to_owned(),
+            draft_extension_negotiated: true,
+            request_id: "req-welcome-a2-rejoin".to_owned(),
+        },
+    )
+    .expect("removed A2 replaces its inactive local group from the fresh Welcome");
+    assert_eq!(
+        inspect_local_group_v2(
+            &a2_store,
+            V2InspectLocalGroupInput {
+                owner_did: alice.did.clone(),
+                owner_device_id: a2_device.device_id.clone(),
+                group_did: GROUP_DID.to_owned(),
+                request_id: "req-inspect-a2-after-rejoin".to_owned(),
+            },
+        )
+        .expect("rejoined A2 has local MLS state")
+        .readiness,
+        V2LocalGroupReadiness::Active
+    );
 }

--- a/typescript/ts_sdk/src/authentication/device-manifest.ts
+++ b/typescript/ts_sdk/src/authentication/device-manifest.ts
@@ -1,0 +1,900 @@
+import { p256 } from '@noble/curves/p256';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import bs58 from 'bs58';
+
+import { DeviceManifestError } from '../errors/index.js';
+import { decodeBase64Url, encodeBase64Url } from '../internal/base64.js';
+
+export const DEVICE_MANIFEST_TYPE = 'ANPDeviceManifest';
+
+export const PROFILE_CORE_BINDING_V1 = 'anp.core.binding.v1';
+export const PROFILE_IDENTITY_DISCOVERY_V1 = 'anp.identity.discovery.v1';
+export const PROFILE_DIRECT_BASE_V1 = 'anp.direct.base.v1';
+export const PROFILE_GROUP_BASE_V1 = 'anp.group.base.v1';
+export const PROFILE_DIRECT_E2EE_V2 = 'anp.direct.e2ee.v2';
+export const PROFILE_GROUP_E2EE_V2 = 'anp.group.e2ee.v2';
+
+export const PROFILE_CORE_BINDING_V2 = 'anp.core.binding.v2';
+export const PROFILE_IDENTITY_DISCOVERY_V2 = 'anp.identity.discovery.v2';
+export const PROFILE_DIRECT_BASE_V2 = 'anp.direct.base.v2';
+export const PROFILE_GROUP_BASE_V2 = 'anp.group.base.v2';
+
+const MANIFEST_FIELDS = new Set(['type', 'devices']);
+const ENTRY_FIELDS = new Set(['device_id', 'signing_key_id', 'e2ee_key_id', 'profiles']);
+const P5_DEPENDENCIES = new Set([
+  PROFILE_CORE_BINDING_V1,
+  PROFILE_IDENTITY_DISCOVERY_V1,
+  PROFILE_DIRECT_BASE_V1,
+  PROFILE_DIRECT_E2EE_V2,
+]);
+const P6_DEPENDENCIES = new Set([
+  PROFILE_CORE_BINDING_V1,
+  PROFILE_IDENTITY_DISCOVERY_V1,
+  PROFILE_GROUP_BASE_V1,
+  PROFILE_GROUP_E2EE_V2,
+]);
+const P5_LEGACY_DRAFT_DEPENDENCIES = new Set([
+  PROFILE_CORE_BINDING_V2,
+  PROFILE_IDENTITY_DISCOVERY_V2,
+  PROFILE_DIRECT_BASE_V2,
+  PROFILE_DIRECT_E2EE_V2,
+]);
+const P6_LEGACY_DRAFT_DEPENDENCIES = new Set([
+  PROFILE_CORE_BINDING_V2,
+  PROFILE_IDENTITY_DISCOVERY_V2,
+  PROFILE_GROUP_BASE_V2,
+  PROFILE_GROUP_E2EE_V2,
+]);
+const LEGACY_DRAFT_FOUNDATION_PROFILES = new Set([
+  PROFILE_CORE_BINDING_V2,
+  PROFILE_IDENTITY_DISCOVERY_V2,
+  PROFILE_DIRECT_BASE_V2,
+  PROFILE_GROUP_BASE_V2,
+]);
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const SIGNING_ALGORITHMS = new Set(['Ed25519', 'P-256', 'secp256k1']);
+
+export type ManifestDidDocument = Record<string, unknown>;
+
+export interface DeviceManifestEntryWire {
+  device_id: string;
+  signing_key_id: string;
+  e2ee_key_id: string;
+  profiles: string[];
+}
+
+export interface DeviceManifestWire {
+  type: string;
+  devices: DeviceManifestEntryWire[];
+}
+
+export class DeviceManifestEntry {
+  constructor(
+    public readonly deviceId: string,
+    public readonly signingKeyId: string,
+    public readonly e2eeKeyId: string,
+    public readonly profiles: readonly string[]
+  ) {}
+
+  static fromWire(value: DeviceManifestEntryWire): DeviceManifestEntry {
+    return new DeviceManifestEntry(value.device_id, value.signing_key_id, value.e2ee_key_id, [
+      ...value.profiles,
+    ]);
+  }
+
+  toDict(): DeviceManifestEntryWire {
+    return {
+      device_id: this.deviceId,
+      signing_key_id: this.signingKeyId,
+      e2ee_key_id: this.e2eeKeyId,
+      profiles: [...this.profiles],
+    };
+  }
+}
+
+export class DeviceManifest {
+  constructor(
+    public readonly type: string,
+    public readonly devices: readonly DeviceManifestEntry[]
+  ) {}
+
+  toDict(): DeviceManifestWire {
+    return {
+      type: this.type,
+      devices: this.devices.map((device) => device.toDict()),
+    };
+  }
+}
+
+interface PublicKeyIdentity {
+  algorithm: string;
+  rawPublicKey: string;
+}
+
+export function parseDeviceManifest(didDocument: ManifestDidDocument): DeviceManifest | null {
+  if (!Object.prototype.hasOwnProperty.call(didDocument, 'deviceManifest')) {
+    return null;
+  }
+  const rawManifest = didDocument.deviceManifest;
+  if (!isPlainObject(rawManifest)) {
+    throw new DeviceManifestError('deviceManifest must be an object');
+  }
+  requireExactFields(rawManifest, MANIFEST_FIELDS, 'deviceManifest');
+  if (rawManifest.type !== DEVICE_MANIFEST_TYPE) {
+    throw new DeviceManifestError('deviceManifest.type must equal ANPDeviceManifest');
+  }
+  const rawDevices = rawManifest.devices;
+  if (!Array.isArray(rawDevices)) {
+    throw new DeviceManifestError('deviceManifest.devices must be an array');
+  }
+
+  const devices: DeviceManifestEntry[] = [];
+  rawDevices.forEach((rawEntry, index) => {
+    const subject = `deviceManifest.devices[${index}]`;
+    if (!isPlainObject(rawEntry)) {
+      throw new DeviceManifestError(`${subject} must be an object`);
+    }
+    requireExactFields(rawEntry, ENTRY_FIELDS, subject);
+    const deviceId = requireString(rawEntry.device_id, `${subject}.device_id`);
+    const signingKeyId = requireString(rawEntry.signing_key_id, `${subject}.signing_key_id`);
+    const e2eeKeyId = requireString(rawEntry.e2ee_key_id, `${subject}.e2ee_key_id`);
+    const rawProfiles = rawEntry.profiles;
+    if (!Array.isArray(rawProfiles)) {
+      throw new DeviceManifestError(`${subject}.profiles must be a string array`);
+    }
+    const profiles = rawProfiles.map((profile) => requireString(profile, `${subject}.profiles[]`));
+    devices.push(new DeviceManifestEntry(deviceId, signingKeyId, e2eeKeyId, profiles));
+  });
+
+  return new DeviceManifest(DEVICE_MANIFEST_TYPE, devices);
+}
+
+export function validateDeviceManifest(didDocument: ManifestDidDocument): DeviceManifest | null {
+  const manifest = parseDeviceManifest(didDocument);
+  if (manifest === null) {
+    return null;
+  }
+
+  const did = requireNonEmptyString(didDocument.id, 'DID document id');
+  const verificationMethods = didDocument.verificationMethod;
+  if (!Array.isArray(verificationMethods)) {
+    throw new DeviceManifestError('DID document verificationMethod must be an array');
+  }
+
+  const methodsById = new Map<string, Record<string, unknown>[]>();
+  for (const method of verificationMethods) {
+    if (!isPlainObject(method)) {
+      continue;
+    }
+    const methodId = method.id;
+    if (typeof methodId === 'string') {
+      const existing = methodsById.get(methodId) ?? [];
+      existing.push(method);
+      methodsById.set(methodId, existing);
+    }
+  }
+
+  const seenDeviceIds = new Set<string>();
+  const seenKeyIds = new Set<string>();
+  for (const entry of manifest.devices) {
+    requireNonEmptyString(entry.deviceId, 'device_id');
+    requireNonEmptyString(entry.signingKeyId, 'signing_key_id');
+    requireNonEmptyString(entry.e2eeKeyId, 'e2ee_key_id');
+    if (entry.profiles.length === 0) {
+      throw new DeviceManifestError('profiles must be non-empty');
+    }
+    for (const profile of entry.profiles) {
+      requireNonEmptyString(profile, 'profile');
+    }
+    if (seenDeviceIds.has(entry.deviceId)) {
+      throw new DeviceManifestError('device_id must be unique');
+    }
+    seenDeviceIds.add(entry.deviceId);
+
+    if (entry.signingKeyId === entry.e2eeKeyId) {
+      throw new DeviceManifestError('signing_key_id and e2ee_key_id must be distinct');
+    }
+    for (const keyId of [entry.signingKeyId, entry.e2eeKeyId]) {
+      if (seenKeyIds.has(keyId)) {
+        throw new DeviceManifestError('a verification method can belong to only one device entry');
+      }
+      seenKeyIds.add(keyId);
+      validateSameDocumentMethod(did, keyId, methodsById);
+    }
+
+    const profileSet = new Set(entry.profiles);
+    if (profileSet.has(PROFILE_DIRECT_E2EE_V2)) {
+      requireDependencies(profileSet, P5_DEPENDENCIES, P5_LEGACY_DRAFT_DEPENDENCIES, 'P5');
+      requireRelationship(didDocument, 'assertionMethod', entry.signingKeyId, 'P5 signing key');
+    }
+    if (profileSet.has(PROFILE_GROUP_E2EE_V2)) {
+      requireDependencies(profileSet, P6_DEPENDENCIES, P6_LEGACY_DRAFT_DEPENDENCIES, 'P6');
+      requireRelationship(didDocument, 'assertionMethod', entry.signingKeyId, 'P6 binding key');
+      requireRelationship(didDocument, 'authentication', entry.signingKeyId, 'P6 origin-proof key');
+    }
+    requireRelationship(didDocument, 'keyAgreement', entry.e2eeKeyId, 'device E2EE key');
+  }
+
+  return manifest;
+}
+
+export function findEligibleDevice(
+  didDocument: ManifestDidDocument,
+  deviceId: string,
+  requiredProfile: string
+): DeviceManifestEntry | null {
+  const manifest = validateDeviceManifest(didDocument);
+  if (manifest === null) {
+    return null;
+  }
+  if (requiredProfile !== PROFILE_DIRECT_E2EE_V2 && requiredProfile !== PROFILE_GROUP_E2EE_V2) {
+    return null;
+  }
+  return (
+    manifest.devices.find(
+      (entry) => entry.deviceId === deviceId && entry.profiles.includes(requiredProfile)
+    ) ?? null
+  );
+}
+
+export function buildVnextDidDocument(
+  baseDocument: ManifestDidDocument,
+  rootKeyId: string,
+  rootVerificationMethod: Record<string, unknown>,
+  device: DeviceManifestEntry,
+  deviceSigningVerificationMethod: Record<string, unknown>,
+  deviceE2eeVerificationMethod: Record<string, unknown>
+): ManifestDidDocument {
+  requireCanonicalWriteProfiles(device);
+  const document = cloneDocument(baseDocument);
+  for (const field of [
+    'verificationMethod',
+    'authentication',
+    'assertionMethod',
+    'keyAgreement',
+    'deviceManifest',
+    'proof',
+  ]) {
+    if (field in document) {
+      throw new DeviceManifestError(`base DID document must not contain managed field ${field}`);
+    }
+  }
+
+  const did = documentDid(document);
+  validateRootMethod(did, rootKeyId, rootVerificationMethod);
+  validateDeviceMethods(
+    did,
+    rootKeyId,
+    device,
+    deviceSigningVerificationMethod,
+    deviceE2eeVerificationMethod
+  );
+  Object.assign(document, {
+    verificationMethod: [
+      structuredClone(rootVerificationMethod),
+      structuredClone(deviceSigningVerificationMethod),
+      structuredClone(deviceE2eeVerificationMethod),
+    ],
+    authentication: [device.signingKeyId],
+    assertionMethod: [rootKeyId, device.signingKeyId],
+    keyAgreement: [device.e2eeKeyId],
+    deviceManifest: {
+      type: DEVICE_MANIFEST_TYPE,
+      devices: [device.toDict()],
+    },
+  });
+  validateVnextDocument(document, rootKeyId);
+  return document;
+}
+
+export function addDeviceToDidDocument(
+  didDocument: ManifestDidDocument,
+  rootKeyId: string,
+  device: DeviceManifestEntry,
+  deviceSigningVerificationMethod: Record<string, unknown>,
+  deviceE2eeVerificationMethod: Record<string, unknown>,
+  retiredDeviceIds: Iterable<string>
+): ManifestDidDocument {
+  requireCanonicalWriteProfiles(device);
+  const document = prepareDocumentForMutation(didDocument, rootKeyId);
+  const manifest = validateDeviceManifest(document);
+  if (manifest === null) {
+    throw new DeviceManifestError('deviceManifest is required for device update');
+  }
+  if (manifest.devices.some((entry) => entry.deviceId === device.deviceId)) {
+    throw new DeviceManifestError('device_id already exists');
+  }
+  const retired = validateRetiredDeviceIds(retiredDeviceIds);
+  if (retired.has(device.deviceId)) {
+    throw new DeviceManifestError('retired device_id cannot be reused');
+  }
+  appendDeviceMaterial(
+    document,
+    rootKeyId,
+    device,
+    deviceSigningVerificationMethod,
+    deviceE2eeVerificationMethod
+  );
+  validateVnextDocument(document, rootKeyId);
+  return document;
+}
+
+export function updateDeviceInDidDocument(
+  didDocument: ManifestDidDocument,
+  rootKeyId: string,
+  device: DeviceManifestEntry,
+  deviceSigningVerificationMethod: Record<string, unknown>,
+  deviceE2eeVerificationMethod: Record<string, unknown>
+): ManifestDidDocument {
+  requireCanonicalWriteProfiles(device);
+  const document = prepareDocumentForMutation(didDocument, rootKeyId);
+  const manifest = validateDeviceManifest(document);
+  if (manifest === null) {
+    throw new DeviceManifestError('deviceManifest is required for device update');
+  }
+  const oldEntry = manifest.devices.find((entry) => entry.deviceId === device.deviceId);
+  if (oldEntry === undefined) {
+    throw new DeviceManifestError('device_id does not exist');
+  }
+  removeDeviceMaterial(document, oldEntry);
+  appendDeviceMaterial(
+    document,
+    rootKeyId,
+    device,
+    deviceSigningVerificationMethod,
+    deviceE2eeVerificationMethod
+  );
+  validateVnextDocument(document, rootKeyId);
+  return document;
+}
+
+export function removeDeviceFromDidDocument(
+  didDocument: ManifestDidDocument,
+  rootKeyId: string,
+  deviceId: string
+): ManifestDidDocument {
+  const document = prepareDocumentForMutation(didDocument, rootKeyId);
+  const manifest = validateDeviceManifest(document);
+  if (manifest === null) {
+    throw new DeviceManifestError('deviceManifest is required for device update');
+  }
+  const oldEntry = manifest.devices.find((entry) => entry.deviceId === deviceId);
+  if (oldEntry === undefined) {
+    throw new DeviceManifestError('device_id does not exist');
+  }
+  removeDeviceMaterial(document, oldEntry);
+  validateVnextDocument(document, rootKeyId);
+  return document;
+}
+
+function cloneDocument(didDocument: ManifestDidDocument): ManifestDidDocument {
+  if (!isPlainObject(didDocument)) {
+    throw new DeviceManifestError('DID document must be an object');
+  }
+  validateJsonValue(didDocument, 'DID document');
+  return structuredClone(didDocument);
+}
+
+function documentDid(didDocument: ManifestDidDocument): string {
+  return requireNonEmptyString(didDocument.id, 'DID document id');
+}
+
+function prepareDocumentForMutation(
+  didDocument: ManifestDidDocument,
+  rootKeyId: string
+): ManifestDidDocument {
+  const document = cloneDocument(didDocument);
+  validateVnextDocument(document, rootKeyId);
+  const manifest = validateDeviceManifest(document);
+  if (manifest === null) {
+    throw new DeviceManifestError('deviceManifest is required');
+  }
+  for (const entry of manifest.devices) {
+    requireCanonicalWriteProfiles(entry);
+  }
+  delete document.proof;
+  return document;
+}
+
+function requireCanonicalWriteProfiles(device: DeviceManifestEntry): void {
+  if (device.profiles.some((profile) => LEGACY_DRAFT_FOUNDATION_PROFILES.has(profile))) {
+    throw new DeviceManifestError(
+      'legacy draft foundation profiles are read-only and cannot be published'
+    );
+  }
+}
+
+function validateVnextDocument(didDocument: ManifestDidDocument, rootKeyId: string): void {
+  validateJsonValue(didDocument, 'DID document');
+  rejectPrivateKeyMaterial(didDocument, 'DID document');
+  const did = documentDid(didDocument);
+  const methods = didDocument.verificationMethod;
+  if (!Array.isArray(methods)) {
+    throw new DeviceManifestError('DID document verificationMethod must be an array');
+  }
+  const rootMethods = methods.filter((method) => isPlainObject(method) && method.id === rootKeyId);
+  if (rootMethods.length !== 1 || !isPlainObject(rootMethods[0])) {
+    throw new DeviceManifestError('root key must resolve exactly once in verificationMethod');
+  }
+  const rootIdentity = validateRootMethod(did, rootKeyId, rootMethods[0]);
+  requireRelationship(didDocument, 'assertionMethod', rootKeyId, 'DID root key');
+  const manifest = validateDeviceManifest(didDocument);
+  if (manifest === null) {
+    throw new DeviceManifestError('deviceManifest is required');
+  }
+  const seenMaterial = new Set([rootIdentity.rawPublicKey]);
+  for (const entry of manifest.devices) {
+    if (rootKeyId === entry.signingKeyId || rootKeyId === entry.e2eeKeyId) {
+      throw new DeviceManifestError('DID root key cannot be a device key');
+    }
+    const signingMethod = uniqueMethod(didDocument, entry.signingKeyId);
+    const e2eeMethod = uniqueMethod(didDocument, entry.e2eeKeyId);
+    const [signingIdentity, e2eeIdentity] = validateDeviceMethods(
+      did,
+      rootKeyId,
+      entry,
+      signingMethod,
+      e2eeMethod
+    );
+    requireRelationship(didDocument, 'authentication', entry.signingKeyId, 'device signing key');
+    requireRelationship(didDocument, 'assertionMethod', entry.signingKeyId, 'device signing key');
+    requireRelationship(didDocument, 'keyAgreement', entry.e2eeKeyId, 'device E2EE key');
+    if (relationshipContains(didDocument, 'keyAgreement', entry.signingKeyId)) {
+      throw new DeviceManifestError('device signing key must not be in keyAgreement');
+    }
+    if (
+      relationshipContains(didDocument, 'authentication', entry.e2eeKeyId) ||
+      relationshipContains(didDocument, 'assertionMethod', entry.e2eeKeyId)
+    ) {
+      throw new DeviceManifestError('device E2EE key must not be a signing relationship');
+    }
+    for (const identity of [signingIdentity, e2eeIdentity]) {
+      if (seenMaterial.has(identity.rawPublicKey)) {
+        throw new DeviceManifestError('root and device public key material must be unique');
+      }
+      seenMaterial.add(identity.rawPublicKey);
+    }
+  }
+}
+
+function validateRootMethod(
+  did: string,
+  rootKeyId: string,
+  verificationMethod: Record<string, unknown>
+): PublicKeyIdentity {
+  return validatePublicMethod(
+    did,
+    rootKeyId,
+    verificationMethod,
+    SIGNING_ALGORITHMS,
+    'DID root verification method'
+  );
+}
+
+function validateDeviceMethods(
+  did: string,
+  rootKeyId: string,
+  device: DeviceManifestEntry,
+  signingMethod: Record<string, unknown>,
+  e2eeMethod: Record<string, unknown>
+): [PublicKeyIdentity, PublicKeyIdentity] {
+  if (rootKeyId === device.signingKeyId || rootKeyId === device.e2eeKeyId) {
+    throw new DeviceManifestError('DID root key cannot be a device key');
+  }
+  const standardObjectProof = device.profiles.some(
+    (profile) => profile === PROFILE_DIRECT_E2EE_V2 || profile === PROFILE_GROUP_E2EE_V2
+  );
+  const signingIdentity = validatePublicMethod(
+    did,
+    device.signingKeyId,
+    signingMethod,
+    standardObjectProof ? new Set(['Ed25519']) : SIGNING_ALGORITHMS,
+    'device signing verification method'
+  );
+  const e2eeIdentity = validatePublicMethod(
+    did,
+    device.e2eeKeyId,
+    e2eeMethod,
+    new Set(['X25519']),
+    'device E2EE verification method'
+  );
+  if (signingIdentity.rawPublicKey === e2eeIdentity.rawPublicKey) {
+    throw new DeviceManifestError('device key material must be unique across roles');
+  }
+  return [signingIdentity, e2eeIdentity];
+}
+
+function validatePublicMethod(
+  did: string,
+  expectedKeyId: string,
+  method: Record<string, unknown>,
+  allowedAlgorithms: Set<string>,
+  subject: string
+): PublicKeyIdentity {
+  if (!isPlainObject(method)) {
+    throw new DeviceManifestError(`${subject} must be an object`);
+  }
+  validateJsonValue(method, subject);
+  if (method.id !== expectedKeyId) {
+    throw new DeviceManifestError(`${subject} id does not match its role`);
+  }
+  if (method.controller !== did) {
+    throw new DeviceManifestError(`${subject} controller must match the DID`);
+  }
+  validateSameDocumentKeyId(did, expectedKeyId);
+  rejectPrivateKeyMaterial(method, subject);
+  const methodType = requireNonEmptyString(method.type, `${subject}.type`);
+  const materialFields = ['publicKeyJwk', 'publicKeyMultibase', 'publicKeyBase58'].filter((field) =>
+    Object.prototype.hasOwnProperty.call(method, field)
+  );
+  if (materialFields.length !== 1) {
+    throw new DeviceManifestError(`${subject} must contain exactly one supported public key field`);
+  }
+  const materialField = materialFields[0];
+  let identity: PublicKeyIdentity;
+  if (materialField === 'publicKeyJwk') {
+    identity = decodePublicJwk(methodType, method[materialField], subject);
+  } else if (materialField === 'publicKeyMultibase') {
+    identity = decodePublicMultikey(methodType, method[materialField], subject);
+  } else {
+    throw new DeviceManifestError(`${subject} publicKeyBase58 is not supported by vNext helpers`);
+  }
+  if (!allowedAlgorithms.has(identity.algorithm)) {
+    throw new DeviceManifestError(`${subject} uses the wrong key algorithm`);
+  }
+  return identity;
+}
+
+function validateSameDocumentKeyId(did: string, keyId: string): void {
+  if (!keyId.startsWith(`${did}#`) || keyId === `${did}#`) {
+    throw new DeviceManifestError('key id must be a DID URL in the same document');
+  }
+}
+
+function decodePublicJwk(methodType: string, value: unknown, subject: string): PublicKeyIdentity {
+  if (
+    methodType !== 'JsonWebKey2020' &&
+    methodType !== 'EcdsaSecp256k1VerificationKey2019' &&
+    methodType !== 'EcdsaSecp256r1VerificationKey2019'
+  ) {
+    throw new DeviceManifestError(`${subject} type is incompatible with publicKeyJwk`);
+  }
+  if (!isPlainObject(value)) {
+    throw new DeviceManifestError(`${subject}.publicKeyJwk must be an object`);
+  }
+  const kty = value.kty;
+  const curve = value.crv;
+  if (kty === 'OKP' && (curve === 'Ed25519' || curve === 'X25519')) {
+    if (methodType !== 'JsonWebKey2020') {
+      throw new DeviceManifestError(`${subject} type contradicts its JWK`);
+    }
+    const raw = decodeCanonicalBase64url32(value.x, `${subject}.x`);
+    return { algorithm: curve, rawPublicKey: encodeRaw(raw) };
+  }
+  if (kty === 'EC' && (curve === 'P-256' || curve === 'secp256k1')) {
+    const expectedType =
+      curve === 'P-256' ? 'EcdsaSecp256r1VerificationKey2019' : 'EcdsaSecp256k1VerificationKey2019';
+    if (methodType !== 'JsonWebKey2020' && methodType !== expectedType) {
+      throw new DeviceManifestError(`${subject} type contradicts its JWK`);
+    }
+    const x = decodeCanonicalBase64url32(value.x, `${subject}.x`);
+    const y = decodeCanonicalBase64url32(value.y, `${subject}.y`);
+    validateEcPoint(curve, x, y, subject);
+    return { algorithm: curve, rawPublicKey: encodeRaw(concatBytes(x, y)) };
+  }
+  throw new DeviceManifestError(`${subject} contains an unsupported public JWK`);
+}
+
+function decodePublicMultikey(
+  methodType: string,
+  value: unknown,
+  subject: string
+): PublicKeyIdentity {
+  if (methodType !== 'Multikey' && methodType !== 'X25519KeyAgreementKey2019') {
+    throw new DeviceManifestError(`${subject} type is incompatible with publicKeyMultibase`);
+  }
+  if (typeof value !== 'string' || !value.startsWith('z') || value.length === 1) {
+    throw new DeviceManifestError(`${subject}.publicKeyMultibase must be base58btc`);
+  }
+  let decoded: Uint8Array;
+  try {
+    decoded = bs58.decode(value.slice(1));
+  } catch (error) {
+    throw new DeviceManifestError(`${subject}.publicKeyMultibase is invalid`, error as Error);
+  }
+  if (`z${bs58.encode(decoded)}` !== value) {
+    throw new DeviceManifestError(`${subject}.publicKeyMultibase must be canonical`);
+  }
+  if (decoded.length !== 34) {
+    throw new DeviceManifestError(`${subject}.publicKeyMultibase must contain a 32-byte key`);
+  }
+  const prefix = decoded[0] * 256 + decoded[1];
+  let algorithm: string;
+  if (prefix === 0xed01) {
+    algorithm = 'Ed25519';
+  } else if (prefix === 0xec01) {
+    algorithm = 'X25519';
+  } else {
+    throw new DeviceManifestError(`${subject}.publicKeyMultibase uses an unsupported codec`);
+  }
+  if (methodType === 'X25519KeyAgreementKey2019' && algorithm !== 'X25519') {
+    throw new DeviceManifestError(`${subject} type contradicts its Multikey`);
+  }
+  return { algorithm, rawPublicKey: encodeRaw(decoded.slice(2)) };
+}
+
+function decodeCanonicalBase64url32(value: unknown, subject: string): Uint8Array {
+  if (typeof value !== 'string' || !BASE64URL_RE.test(value)) {
+    throw new DeviceManifestError(`${subject} must be unpadded base64url`);
+  }
+  let decoded: Uint8Array;
+  try {
+    decoded = decodeBase64Url(value);
+  } catch (error) {
+    throw new DeviceManifestError(`${subject} is invalid base64url`, error as Error);
+  }
+  const canonical = encodeBase64Url(decoded);
+  if (decoded.length !== 32 || canonical !== value) {
+    throw new DeviceManifestError(`${subject} must canonically encode 32 bytes`);
+  }
+  return decoded;
+}
+
+function validateEcPoint(
+  curve: 'P-256' | 'secp256k1',
+  x: Uint8Array,
+  y: Uint8Array,
+  subject: string
+): void {
+  const uncompressed = new Uint8Array(65);
+  uncompressed[0] = 0x04;
+  uncompressed.set(x, 1);
+  uncompressed.set(y, 33);
+  try {
+    if (curve === 'P-256') {
+      p256.ProjectivePoint.fromHex(uncompressed);
+    } else {
+      secp256k1.ProjectivePoint.fromHex(uncompressed);
+    }
+  } catch (error) {
+    throw new DeviceManifestError(`${subject} contains an invalid EC point`, error as Error);
+  }
+}
+
+function rejectPrivateKeyMaterial(value: unknown, subject: string): void {
+  if (isPlainObject(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      const normalizedKey = key.toLowerCase().replaceAll('_', '').replaceAll('-', '');
+      if (normalizedKey.includes('privatekey') || (key === 'd' && 'kty' in value)) {
+        throw new DeviceManifestError(`${subject} must not contain private key material`);
+      }
+      rejectPrivateKeyMaterial(nested, subject);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const nested of value) {
+      rejectPrivateKeyMaterial(nested, subject);
+    }
+  }
+}
+
+function validateJsonValue(value: unknown, subject: string): void {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new DeviceManifestError(`${subject} contains a non-finite number`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const nested of value) {
+      validateJsonValue(nested, subject);
+    }
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      if (typeof key !== 'string') {
+        throw new DeviceManifestError(`${subject} contains a non-string object key`);
+      }
+      validateJsonValue(nested, subject);
+    }
+    return;
+  }
+  throw new DeviceManifestError(`${subject} contains a non-JSON value`);
+}
+
+function validateRetiredDeviceIds(retiredDeviceIds: Iterable<string>): Set<string> {
+  if (typeof retiredDeviceIds === 'string') {
+    throw new DeviceManifestError('retired_device_ids must be a string collection');
+  }
+  const values: string[] = [];
+  try {
+    for (const deviceId of retiredDeviceIds) {
+      values.push(deviceId);
+    }
+  } catch (error) {
+    throw new DeviceManifestError('retired_device_ids must be a string collection', error as Error);
+  }
+  for (const deviceId of values) {
+    requireNonEmptyString(deviceId, 'retired device_id');
+  }
+  return new Set(values);
+}
+
+function uniqueMethod(didDocument: ManifestDidDocument, keyId: string): Record<string, unknown> {
+  const methods = didDocument.verificationMethod;
+  if (!Array.isArray(methods)) {
+    throw new DeviceManifestError('DID document verificationMethod must be an array');
+  }
+  const matches = methods.filter((method) => isPlainObject(method) && method.id === keyId);
+  if (matches.length !== 1 || !isPlainObject(matches[0])) {
+    throw new DeviceManifestError('key id must resolve exactly once in verificationMethod');
+  }
+  return matches[0];
+}
+
+function appendDeviceMaterial(
+  document: ManifestDidDocument,
+  rootKeyId: string,
+  device: DeviceManifestEntry,
+  signingMethod: Record<string, unknown>,
+  e2eeMethod: Record<string, unknown>
+): void {
+  const did = documentDid(document);
+  validateDeviceMethods(did, rootKeyId, device, signingMethod, e2eeMethod);
+  const methods = document.verificationMethod;
+  const authentication = document.authentication;
+  const assertionMethod = document.assertionMethod;
+  const keyAgreement = document.keyAgreement;
+  const manifest = document.deviceManifest;
+  if (
+    !Array.isArray(methods) ||
+    !Array.isArray(authentication) ||
+    !Array.isArray(assertionMethod) ||
+    !Array.isArray(keyAgreement) ||
+    !isPlainObject(manifest) ||
+    !Array.isArray(manifest.devices)
+  ) {
+    throw new DeviceManifestError('DID document relationships are invalid');
+  }
+  methods.push(structuredClone(signingMethod), structuredClone(e2eeMethod));
+  authentication.push(device.signingKeyId);
+  assertionMethod.push(device.signingKeyId);
+  keyAgreement.push(device.e2eeKeyId);
+  manifest.devices.push(device.toDict());
+}
+
+function removeDeviceMaterial(document: ManifestDidDocument, device: DeviceManifestEntry): void {
+  const keyIds = new Set([device.signingKeyId, device.e2eeKeyId]);
+  const methods = document.verificationMethod;
+  if (!Array.isArray(methods)) {
+    throw new DeviceManifestError('DID document verificationMethod must be an array');
+  }
+  document.verificationMethod = methods.filter(
+    (method) => !(isPlainObject(method) && typeof method.id === 'string' && keyIds.has(method.id))
+  );
+  for (const relationship of ['authentication', 'assertionMethod', 'keyAgreement']) {
+    const entries = document[relationship];
+    if (!Array.isArray(entries)) {
+      throw new DeviceManifestError(`${relationship} must be an array`);
+    }
+    document[relationship] = entries.filter(
+      (entry) => ![...keyIds].some((keyId) => relationshipEntryIs(entry, keyId))
+    );
+  }
+  const manifest = document.deviceManifest;
+  if (!isPlainObject(manifest) || !Array.isArray(manifest.devices)) {
+    throw new DeviceManifestError('deviceManifest.devices must be an array');
+  }
+  manifest.devices = manifest.devices.filter(
+    (entry) => !(isPlainObject(entry) && entry.device_id === device.deviceId)
+  );
+}
+
+function relationshipEntryIs(entry: unknown, keyId: string): boolean {
+  return entry === keyId || (isPlainObject(entry) && entry.id === keyId);
+}
+
+function relationshipContains(
+  didDocument: ManifestDidDocument,
+  relationship: string,
+  keyId: string
+): boolean {
+  const entries = didDocument[relationship];
+  return Array.isArray(entries) && entries.some((entry) => relationshipEntryIs(entry, keyId));
+}
+
+function requireExactFields(
+  value: Record<string, unknown>,
+  expected: Set<string>,
+  subject: string
+): void {
+  const actual = new Set(Object.keys(value));
+  if (actual.size !== expected.size || [...expected].some((field) => !actual.has(field))) {
+    throw new DeviceManifestError(
+      `${subject} must contain exactly ${[...expected].sort().join(', ')}`
+    );
+  }
+}
+
+function requireString(value: unknown, subject: string): string {
+  if (typeof value !== 'string') {
+    throw new DeviceManifestError(`${subject} must be a string`);
+  }
+  return value;
+}
+
+function requireNonEmptyString(value: unknown, subject: string): string {
+  const result = requireString(value, subject);
+  if (!result) {
+    throw new DeviceManifestError(`${subject} must be a non-empty string`);
+  }
+  return result;
+}
+
+function validateSameDocumentMethod(
+  did: string,
+  keyId: string,
+  methodsById: Map<string, Record<string, unknown>[]>
+): void {
+  if (!keyId.startsWith(`${did}#`) || keyId === `${did}#`) {
+    throw new DeviceManifestError('device key IDs must be DID URLs in the same DID document');
+  }
+  const methods = methodsById.get(keyId) ?? [];
+  if (methods.length !== 1) {
+    throw new DeviceManifestError('device key ID must resolve exactly once in verificationMethod');
+  }
+}
+
+function requireDependencies(
+  profiles: Set<string>,
+  required: Set<string>,
+  legacyDraft: Set<string>,
+  profileName: string
+): void {
+  const hasRequired = [...required].every((profile) => profiles.has(profile));
+  const hasLegacy = [...legacyDraft].every((profile) => profiles.has(profile));
+  if (!hasRequired && !hasLegacy) {
+    throw new DeviceManifestError(`${profileName} device profile dependencies are incomplete`);
+  }
+}
+
+function requireRelationship(
+  didDocument: ManifestDidDocument,
+  relationship: string,
+  keyId: string,
+  subject: string
+): void {
+  const entries = didDocument[relationship];
+  if (!Array.isArray(entries)) {
+    throw new DeviceManifestError(`${subject} requires ${relationship}`);
+  }
+  for (const entry of entries) {
+    if (entry === keyId) {
+      return;
+    }
+    if (isPlainObject(entry) && entry.id === keyId) {
+      return;
+    }
+  }
+  throw new DeviceManifestError(`${subject} is not authorized by ${relationship}`);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function encodeRaw(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const output = new Uint8Array(left.length + right.length);
+  output.set(left);
+  output.set(right, left.length);
+  return output;
+}

--- a/typescript/ts_sdk/src/authentication/index.ts
+++ b/typescript/ts_sdk/src/authentication/index.ts
@@ -6,6 +6,7 @@ export * from './http-signatures.js';
 export * from './did-wba-authenticator.js';
 export * from './did-wba-verifier.js';
 export * from './federation.js';
+export * from './device-manifest.js';
 
 export {
   createDidWbaDocument as createDidDocument,
@@ -60,6 +61,7 @@ import {
 import { DIDWbaAuthHeader } from './did-wba-authenticator.js';
 import { DidWbaVerifier } from './did-wba-verifier.js';
 import { verifyFederatedHttpRequest } from './federation.js';
+import * as deviceManifest from './device-manifest.js';
 
 export const didDocuments = {
   ANP_MESSAGE_SERVICE_TYPE,
@@ -93,6 +95,7 @@ export const authentication = {
   didDocuments,
   legacyAuth,
   httpSignatures,
+  deviceManifest,
   federation: {
     verifyRequest: verifyFederatedHttpRequest,
   },

--- a/typescript/ts_sdk/src/authentication/types.ts
+++ b/typescript/ts_sdk/src/authentication/types.ts
@@ -64,6 +64,15 @@ export interface DidDocument {
   keyAgreement?: Array<string | VerificationMethodRecord>;
   service?: ServiceRecord[];
   proof?: ProofRecord;
+  deviceManifest?: {
+    type: string;
+    devices: Array<{
+      device_id: string;
+      signing_key_id: string;
+      e2ee_key_id: string;
+      profiles: string[];
+    }>;
+  };
 }
 
 export interface DidDocumentOptions {

--- a/typescript/ts_sdk/src/errors/index.ts
+++ b/typescript/ts_sdk/src/errors/index.ts
@@ -26,6 +26,14 @@ export class ProofError extends ANPError {
   }
 }
 
+export class DeviceManifestError extends AuthenticationError {
+  constructor(message: string, cause?: Error) {
+    super(message, cause);
+    this.name = 'DeviceManifestError';
+    Object.defineProperty(this, 'code', { value: 'DEVICE_MANIFEST_ERROR' });
+  }
+}
+
 export class NetworkError extends ANPError {
   constructor(message: string, public readonly statusCode?: number, cause?: Error) {
     super(message, 'NETWORK_ERROR', cause);

--- a/typescript/ts_sdk/src/proof/index.ts
+++ b/typescript/ts_sdk/src/proof/index.ts
@@ -1,5 +1,6 @@
 export * from './proof.js';
 export * from './im.js';
+export * from './rfc9421-origin.js';
 
 export {
   generateW3cProof as createProof,
@@ -13,10 +14,12 @@ import {
   verifyW3cProofDetailed,
 } from './proof.js';
 import * as imProof from './im.js';
+import * as rfc9421Origin from './rfc9421-origin.js';
 
 export const proof = {
   create: generateW3cProof,
   verify: verifyW3cProof,
   verifyDetailed: verifyW3cProofDetailed,
   im: imProof,
+  rfc9421: rfc9421Origin,
 };

--- a/typescript/ts_sdk/src/proof/rfc9421-origin.ts
+++ b/typescript/ts_sdk/src/proof/rfc9421-origin.ts
@@ -1,0 +1,261 @@
+import { ProofError } from '../errors/index.js';
+import { canonicalizeJson, cloneJson, type JsonObject } from '../internal/json.js';
+import type { PrivateKeyInput } from '../internal/keys.js';
+import {
+  IM_PROOF_DEFAULT_COMPONENTS,
+  IM_PROOF_RELATION_AUTHENTICATION,
+  buildImContentDigest,
+  buildImSignatureInput,
+  generateImProof,
+  parseImSignatureInput,
+  verifyImProof,
+  type ImProof,
+  type ImProofVerificationResult,
+} from './im.js';
+import type { DidDocument, VerificationMethodRecord } from '../authentication/types.js';
+
+export const RFC9421_ORIGIN_PROOF_DEFAULT_LABEL = 'sig1';
+export const RFC9421_ORIGIN_PROOF_DEFAULT_COMPONENTS = IM_PROOF_DEFAULT_COMPONENTS;
+export const TARGET_KIND_AGENT = 'agent';
+export const TARGET_KIND_GROUP = 'group';
+export const TARGET_KIND_SERVICE = 'service';
+
+const ALLOWED_TARGET_KINDS = new Set([TARGET_KIND_AGENT, TARGET_KIND_GROUP, TARGET_KIND_SERVICE]);
+
+export class Rfc9421OriginProofError extends ProofError {
+  constructor(message: string, cause?: Error) {
+    super(message, cause);
+    this.name = 'Rfc9421OriginProofError';
+  }
+}
+
+export interface SignedRequestObject {
+  method: string;
+  meta: JsonObject;
+  body: JsonObject;
+}
+
+export type Rfc9421OriginProof = ImProof;
+
+export interface Rfc9421OriginProofGenerationOptions {
+  created?: number;
+  expires?: number;
+  nonce?: string;
+  label?: string;
+}
+
+export interface Rfc9421OriginProofVerificationOptions {
+  expectedSignerDid?: string;
+}
+
+export function buildSignedRequestObject(
+  method: string,
+  meta: Record<string, unknown>,
+  body: Record<string, unknown>
+): SignedRequestObject {
+  if (typeof method !== 'string' || !method.trim()) {
+    throw new Rfc9421OriginProofError('method is required');
+  }
+  if (!isPlainObject(meta)) {
+    throw new Rfc9421OriginProofError('meta must be an object');
+  }
+  if (!isPlainObject(body)) {
+    throw new Rfc9421OriginProofError('body must be an object');
+  }
+  return {
+    method,
+    meta: cloneJson(meta) as JsonObject,
+    body: cloneJson(body) as JsonObject,
+  };
+}
+
+export function canonicalizeSignedRequestObject(
+  signedRequestObject: SignedRequestObject | Record<string, unknown>
+): Uint8Array {
+  const keys = Object.keys(signedRequestObject);
+  if (
+    keys.length !== 3 ||
+    !keys.includes('method') ||
+    !keys.includes('meta') ||
+    !keys.includes('body')
+  ) {
+    throw new Rfc9421OriginProofError(
+      'signed request object must contain only method, meta, and body'
+    );
+  }
+  return canonicalizeJson({
+    method: signedRequestObject.method,
+    meta: signedRequestObject.meta,
+    body: signedRequestObject.body,
+  });
+}
+
+export function buildLogicalTargetUri(targetKind: string, targetDid: string): string {
+  const normalizedKind = String(targetKind).trim();
+  if (!ALLOWED_TARGET_KINDS.has(normalizedKind)) {
+    throw new Rfc9421OriginProofError(`unsupported target kind: ${targetKind}`);
+  }
+  const normalizedDid = String(targetDid).trim();
+  if (!normalizedDid) {
+    throw new Rfc9421OriginProofError('target did is required');
+  }
+  return `anp://${normalizedKind}/${quoteRfc3986Unreserved(normalizedDid)}`;
+}
+
+export function buildRfc9421OriginSignatureBase(
+  method: string,
+  logicalTargetUri: string,
+  contentDigest: string,
+  signatureInput: string
+): Uint8Array {
+  if (typeof method !== 'string' || !method.trim()) {
+    throw new Rfc9421OriginProofError('method is required');
+  }
+  if (typeof logicalTargetUri !== 'string' || !logicalTargetUri.trim()) {
+    throw new Rfc9421OriginProofError('logical_target_uri is required');
+  }
+  if (typeof contentDigest !== 'string' || !contentDigest.trim()) {
+    throw new Rfc9421OriginProofError('content_digest is required');
+  }
+  const parsed = parseImSignatureInput(signatureInput);
+  validateParsedSignatureInput(parsed.label, parsed.components);
+  const componentValues: Record<string, string> = {
+    '@method': method,
+    '@target-uri': logicalTargetUri,
+    'content-digest': contentDigest,
+  };
+  const lines = parsed.components.map(
+    (component) => `"${component}": ${componentValues[component]}`
+  );
+  lines.push(`"@signature-params": ${parsed.signatureParams}`);
+  return new TextEncoder().encode(lines.join('\n'));
+}
+
+export function generateRfc9421OriginProof(
+  method: string,
+  meta: Record<string, unknown>,
+  body: Record<string, unknown>,
+  privateKey: PrivateKeyInput,
+  keyId: string,
+  options: Rfc9421OriginProofGenerationOptions = {}
+): Rfc9421OriginProof {
+  const label = options.label ?? RFC9421_ORIGIN_PROOF_DEFAULT_LABEL;
+  validateLabel(label);
+  const signedRequestObject = buildSignedRequestObject(method, meta, body);
+  const canonicalRequest = canonicalizeSignedRequestObject(signedRequestObject);
+  const logicalTargetUri = buildLogicalTargetUriFromMeta(signedRequestObject.meta);
+  const contentDigest = buildImContentDigest(canonicalRequest);
+  const signatureInput = buildImSignatureInput(keyId, {
+    components: [...RFC9421_ORIGIN_PROOF_DEFAULT_COMPONENTS],
+    label,
+    created: options.created,
+    expires: options.expires,
+    nonce: options.nonce,
+  });
+  const signatureBase = buildRfc9421OriginSignatureBase(
+    method,
+    logicalTargetUri,
+    contentDigest,
+    signatureInput
+  );
+  const proof = generateImProof(canonicalRequest, signatureBase, privateKey, keyId, {
+    components: [...RFC9421_ORIGIN_PROOF_DEFAULT_COMPONENTS],
+    label,
+    created: options.created,
+    expires: options.expires,
+    nonce: options.nonce,
+  });
+  const parsed = parseImSignatureInput(proof.signatureInput);
+  validateParsedSignatureInput(parsed.label, parsed.components);
+  return proof;
+}
+
+export function verifyRfc9421OriginProof(
+  originProof: Rfc9421OriginProof,
+  method: string,
+  meta: Record<string, unknown>,
+  body: Record<string, unknown>,
+  verification: {
+    didDocument?: DidDocument;
+    verificationMethod?: VerificationMethodRecord;
+    options?: Rfc9421OriginProofVerificationOptions;
+  } = {}
+): ImProofVerificationResult {
+  const signedRequestObject = buildSignedRequestObject(method, meta, body);
+  const canonicalRequest = canonicalizeSignedRequestObject(signedRequestObject);
+  const logicalTargetUri = buildLogicalTargetUriFromMeta(signedRequestObject.meta);
+  const signatureInput = requireProofField(originProof, 'signatureInput');
+  const parsed = parseImSignatureInput(signatureInput);
+  validateParsedSignatureInput(parsed.label, parsed.components);
+  const signatureBase = buildRfc9421OriginSignatureBase(
+    method,
+    logicalTargetUri,
+    requireProofField(originProof, 'contentDigest'),
+    signatureInput
+  );
+  return verifyImProof(
+    originProof,
+    canonicalRequest,
+    signatureBase,
+    {
+      didDocument: verification.didDocument,
+      verificationMethod: verification.verificationMethod,
+      verificationRelationship: IM_PROOF_RELATION_AUTHENTICATION,
+    },
+    verification.options?.expectedSignerDid
+  );
+}
+
+function buildLogicalTargetUriFromMeta(meta: JsonObject): string {
+  const target = meta.target;
+  if (!isPlainObject(target)) {
+    throw new Rfc9421OriginProofError('meta.target is required');
+  }
+  return buildLogicalTargetUri(String(target.kind), String(target.did));
+}
+
+function validateLabel(label: string): void {
+  if (label !== RFC9421_ORIGIN_PROOF_DEFAULT_LABEL) {
+    throw new Rfc9421OriginProofError('RFC 9421 origin proof requires signature label sig1');
+  }
+}
+
+function validateParsedSignatureInput(label: string, components: string[]): void {
+  validateLabel(label);
+  const expected = [...RFC9421_ORIGIN_PROOF_DEFAULT_COMPONENTS];
+  if (
+    components.length !== expected.length ||
+    components.some((value, index) => value !== expected[index])
+  ) {
+    throw new Rfc9421OriginProofError(
+      'RFC 9421 origin proof requires covered components ("@method" "@target-uri" "content-digest")'
+    );
+  }
+}
+
+function requireProofField(proof: Rfc9421OriginProof, field: keyof Rfc9421OriginProof): string {
+  const value = proof[field];
+  if (!value) {
+    throw new Rfc9421OriginProofError(`missing proof field: ${field}`);
+  }
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Percent-encode like Python urllib.parse.quote(..., safe="-._~"). */
+export function quoteRfc3986Unreserved(value: string): string {
+  let output = '';
+  for (const char of value) {
+    if (/[A-Za-z0-9\-._~]/.test(char)) {
+      output += char;
+      continue;
+    }
+    for (const byte of new TextEncoder().encode(char)) {
+      output += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+  return output;
+}

--- a/typescript/ts_sdk/tests/device-manifest.test.ts
+++ b/typescript/ts_sdk/tests/device-manifest.test.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  DeviceManifestEntry,
+  DeviceManifestError,
+  addDeviceToDidDocument,
+  buildVnextDidDocument,
+  findEligibleDevice,
+  parseDeviceManifest,
+  removeDeviceFromDidDocument,
+  updateDeviceInDidDocument,
+  validateDeviceManifest,
+} from '../src/index.js';
+
+const testdataDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../testdata/device_manifest'
+);
+
+function loadJson(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(testdataDir, name), 'utf8')) as Record<string, unknown>;
+}
+
+describe('Device Manifest fixtures', () => {
+  const fixtures = loadJson('vnext_device_manifest_fixtures.json');
+  const base = fixtures.base_did_document as Record<string, unknown>;
+  const valid = fixtures.valid as Array<Record<string, unknown>>;
+  const invalid = fixtures.invalid as Array<Record<string, unknown>>;
+
+  function buildDocument(caseRecord: Record<string, unknown>): Record<string, unknown> {
+    const document = structuredClone(base);
+    Object.assign(
+      document,
+      structuredClone((caseRecord.document_patch ?? {}) as Record<string, unknown>)
+    );
+    document.deviceManifest = structuredClone(caseRecord.device_manifest);
+    return document;
+  }
+
+  test.each(valid.map((item) => [item.name, item] as const))(
+    'accepts valid case %s',
+    (_name, caseRecord) => {
+      const document = buildDocument(caseRecord);
+      const before = structuredClone(document);
+      const parsed = parseDeviceManifest(document);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.toDict()).toEqual(caseRecord.device_manifest);
+      expect(validateDeviceManifest(document)?.toDict()).toEqual(parsed?.toDict());
+      const lookup = caseRecord.lookup as { device_id: string; profile: string; found: boolean };
+      const device = findEligibleDevice(document, lookup.device_id, lookup.profile);
+      expect(device !== null).toBe(lookup.found);
+      expect(document).toEqual(before);
+      expect(
+        (document['x-fixture-extension'] as { must_survive_validation: boolean })
+          .must_survive_validation
+      ).toBe(true);
+      const wire = JSON.stringify(parsed?.toDict());
+      expect(wire).toContain('"device_id"');
+      expect(wire).toContain('"signing_key_id"');
+      expect(wire).toContain('"e2ee_key_id"');
+      expect(wire).toContain('"profiles"');
+      expect(wire).not.toContain('"deviceId"');
+      expect(wire).not.toContain('"signingKeyId"');
+      expect(wire).not.toContain('"e2eeKeyId"');
+    }
+  );
+
+  test.each(invalid.map((item) => [item.name, item] as const))(
+    'rejects invalid case %s',
+    (_name, caseRecord) => {
+      const document = buildDocument(caseRecord);
+      expect(() => validateDeviceManifest(document)).toThrow(DeviceManifestError);
+    }
+  );
+
+  test('missing manifest is valid and does not invent a device', () => {
+    const document = structuredClone(base);
+    expect(parseDeviceManifest(document)).toBeNull();
+    expect(validateDeviceManifest(document)).toBeNull();
+    expect(findEligibleDevice(document, 'dev-a-7N3KQ2', 'anp.direct.e2ee.v2')).toBeNull();
+  });
+});
+
+describe('vNext DID builder fixtures', () => {
+  const fixture = loadJson('vnext_did_builder_fixtures.json');
+
+  function entry(deviceFixture: Record<string, unknown>): DeviceManifestEntry {
+    const value = deviceFixture.entry as {
+      device_id: string;
+      signing_key_id: string;
+      e2ee_key_id: string;
+      profiles: string[];
+    };
+    return DeviceManifestEntry.fromWire(value);
+  }
+
+  function build(): Record<string, unknown> {
+    const device = fixture.device_a as Record<string, unknown>;
+    return buildVnextDidDocument(
+      fixture.base_document as Record<string, unknown>,
+      fixture.root_key_id as string,
+      fixture.root_verification_method as Record<string, unknown>,
+      entry(device),
+      device.signing_verification_method as Record<string, unknown>,
+      device.e2ee_verification_method as Record<string, unknown>
+    );
+  }
+
+  test('build/add/update/remove match shared vectors and keep snake_case wire keys', () => {
+    const baseBefore = structuredClone(fixture.base_document);
+    const built = build();
+    expect(built).toEqual(fixture.expected_build);
+    expect(fixture.base_document).toEqual(baseBefore);
+    expect(built['x-example']).toEqual(
+      (fixture.base_document as Record<string, unknown>)['x-example']
+    );
+
+    const wire = JSON.stringify((built.deviceManifest as { devices: unknown[] }).devices);
+    expect(wire).toContain('"device_id"');
+    expect(wire).not.toContain('"deviceId"');
+
+    const withStaleProof = { ...built, proof: { proofValue: 'stale' } };
+    const deviceB = fixture.device_b as Record<string, unknown>;
+    const added = addDeviceToDidDocument(
+      withStaleProof,
+      fixture.root_key_id as string,
+      entry(deviceB),
+      deviceB.signing_verification_method as Record<string, unknown>,
+      deviceB.e2ee_verification_method as Record<string, unknown>,
+      fixture.retired_device_ids as string[]
+    );
+    expect(added).toEqual(fixture.expected_add);
+    expect(added.proof).toBeUndefined();
+    expect(withStaleProof.proof).toEqual({ proofValue: 'stale' });
+
+    const rotated = fixture.device_b_rotated as Record<string, unknown>;
+    const updated = updateDeviceInDidDocument(
+      added,
+      fixture.root_key_id as string,
+      entry(rotated),
+      rotated.signing_verification_method as Record<string, unknown>,
+      rotated.e2ee_verification_method as Record<string, unknown>
+    );
+    expect(updated).toEqual(fixture.expected_update);
+
+    const removed = removeDeviceFromDidDocument(
+      updated,
+      fixture.root_key_id as string,
+      (rotated.entry as { device_id: string }).device_id
+    );
+    expect(removed).toEqual(fixture.expected_remove);
+    expect((removed.deviceManifest as { devices: unknown[] }).devices).toEqual(
+      (built.deviceManifest as { devices: unknown[] }).devices
+    );
+    expect(validateDeviceManifest(removed)).not.toBeNull();
+  });
+
+  test('rejects root-as-device-key and private key material', () => {
+    const device = structuredClone(fixture.device_a) as Record<string, unknown>;
+    const deviceEntry = structuredClone(device.entry) as Record<string, unknown>;
+    deviceEntry.signing_key_id = fixture.root_key_id;
+    device.entry = deviceEntry;
+    device.signing_verification_method = structuredClone(fixture.root_verification_method);
+    expect(() =>
+      buildVnextDidDocument(
+        fixture.base_document as Record<string, unknown>,
+        fixture.root_key_id as string,
+        fixture.root_verification_method as Record<string, unknown>,
+        entry(device),
+        device.signing_verification_method as Record<string, unknown>,
+        device.e2ee_verification_method as Record<string, unknown>
+      )
+    ).toThrow(/root key/);
+
+    const privateRoot = structuredClone(fixture.root_verification_method) as Record<
+      string,
+      unknown
+    >;
+    const jwk = structuredClone(privateRoot.publicKeyJwk) as Record<string, unknown>;
+    jwk.d = 'PRIVATE';
+    privateRoot.publicKeyJwk = jwk;
+    expect(() =>
+      buildVnextDidDocument(
+        fixture.base_document as Record<string, unknown>,
+        fixture.root_key_id as string,
+        privateRoot,
+        entry(fixture.device_a as Record<string, unknown>),
+        (fixture.device_a as Record<string, unknown>).signing_verification_method as Record<
+          string,
+          unknown
+        >,
+        (fixture.device_a as Record<string, unknown>).e2ee_verification_method as Record<
+          string,
+          unknown
+        >
+      )
+    ).toThrow(/private key/);
+  });
+});

--- a/typescript/ts_sdk/tests/public-api.test.ts
+++ b/typescript/ts_sdk/tests/public-api.test.ts
@@ -4,16 +4,22 @@ import {
   DidProfile,
   AwikiImError,
   authentication,
+  buildVnextDidDocument,
   createDidDocument,
   createLegacyAuthHeader,
   createAwikiImClient,
   createProof,
+  DeviceManifestEntry,
+  generateRfc9421OriginProof,
   parseUri,
   proof,
   resolveUri,
+  validateDeviceManifest,
   verifyProof,
+  verifyRfc9421OriginProof,
   wns,
 } from '../src/index.js';
+import * as sdk from '../src/index.js';
 
 describe('public API aliases', () => {
   test('exposes stable authentication aliases and namespace', () => {
@@ -46,6 +52,15 @@ describe('public API aliases', () => {
     expect(proof.verify(signed, bundle.keys['key-1'].publicKeyPem)).toBe(true);
     expect(proof.im.generateImProof).toBeTypeOf('function');
     expect(proof.im.verifyImProof).toBeTypeOf('function');
+    expect(generateRfc9421OriginProof).toBeTypeOf('function');
+    expect(verifyRfc9421OriginProof).toBeTypeOf('function');
+    expect(proof.rfc9421.generateRfc9421OriginProof).toBeTypeOf('function');
+    expect(DeviceManifestEntry).toBeTypeOf('function');
+    expect(buildVnextDidDocument).toBeTypeOf('function');
+    expect(validateDeviceManifest).toBeTypeOf('function');
+    expect(authentication.deviceManifest.buildVnextDidDocument).toBeTypeOf('function');
+    expect('buildOriginAuthentication' in sdk).toBe(false);
+    expect((sdk as Record<string, unknown>).buildOriginAuthentication).toBeUndefined();
   });
 
   test('exposes stable wns aliases and namespace', async () => {

--- a/typescript/ts_sdk/tests/rfc9421-origin.test.ts
+++ b/typescript/ts_sdk/tests/rfc9421-origin.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  DidProfile,
+  RFC9421_ORIGIN_PROOF_DEFAULT_LABEL,
+  Rfc9421OriginProofError,
+  buildLogicalTargetUri,
+  buildSignedRequestObject,
+  canonicalizeSignedRequestObject,
+  createDidDocument,
+  generateRfc9421OriginProof,
+  verifyRfc9421OriginProof,
+} from '../src/index.js';
+import { canonicalizeJson } from '../src/internal/json.js';
+
+const DIRECT_META = {
+  anp_version: '1.0',
+  profile: 'anp.direct.base.v1',
+  security_profile: 'transport-protected',
+  sender_did: 'did:wba:example.com:user:alice:e1_alice',
+  target: {
+    kind: 'agent',
+    did: 'did:wba:example.com:user:bob:e1_bob',
+  },
+  operation_id: 'op-1',
+  message_id: 'msg-1',
+  content_type: 'text/plain',
+};
+
+describe('RFC 9421 origin proof', () => {
+  test('canonicalizes only method, meta, and body', () => {
+    const signed = buildSignedRequestObject('direct.send', DIRECT_META, { text: 'hello' });
+    const canonical = canonicalizeSignedRequestObject(signed);
+    expect(Buffer.from(canonical).toString('utf8')).toBe(
+      Buffer.from(
+        canonicalizeJson({
+          method: 'direct.send',
+          meta: signed.meta,
+          body: { text: 'hello' },
+        })
+      ).toString('utf8')
+    );
+    const text = Buffer.from(canonical).toString('utf8');
+    expect(text).not.toContain('"auth"');
+    expect(text).not.toContain('"client"');
+    expect(text).not.toContain('"jsonrpc"');
+  });
+
+  test('builds a percent-encoded logical target URI', () => {
+    expect(
+      buildLogicalTargetUri('service', 'did:wba:example.com:services:message:e1_service')
+    ).toBe('anp://service/did%3Awba%3Aexample.com%3Aservices%3Amessage%3Ae1_service');
+  });
+
+  test('generates and verifies a direct origin proof with caller created/nonce', () => {
+    const bundle = createDidDocument('example.com', {
+      pathSegments: ['user', 'alice'],
+      didProfile: DidProfile.E1,
+      enableE2ee: false,
+    });
+    const meta = {
+      ...DIRECT_META,
+      sender_did: bundle.didDocument.id,
+    };
+    const body = { text: 'hello' };
+    const proof = generateRfc9421OriginProof(
+      'direct.send',
+      meta,
+      body,
+      bundle.keys['key-1'].privateKeyPem,
+      `${bundle.didDocument.id}#key-1`,
+      { created: 1712000000, nonce: 'nonce-1' }
+    );
+
+    expect(proof.signatureInput).toContain('created=1712000000');
+    expect(proof.signatureInput).toContain('nonce="nonce-1"');
+
+    const result = verifyRfc9421OriginProof(proof, 'direct.send', meta, body, {
+      didDocument: bundle.didDocument,
+      options: { expectedSignerDid: bundle.didDocument.id },
+    });
+    expect(result.parsedSignatureInput.label).toBe(RFC9421_ORIGIN_PROOF_DEFAULT_LABEL);
+    expect(result.parsedSignatureInput.components).toEqual([
+      '@method',
+      '@target-uri',
+      'content-digest',
+    ]);
+    expect(result.parsedSignatureInput.nonce).toBe('nonce-1');
+    expect(result.parsedSignatureInput.created).toBe(1712000000);
+  });
+
+  test('generates and verifies a group.create origin proof', () => {
+    const bundle = createDidDocument('example.com', {
+      pathSegments: ['user', 'alice'],
+      didProfile: DidProfile.E1,
+      enableE2ee: false,
+    });
+    const serviceDid = 'did:wba:example.com:services:message:e1_service';
+    const meta = {
+      anp_version: '1.0',
+      profile: 'anp.group.base.v1',
+      security_profile: 'transport-protected',
+      sender_did: bundle.didDocument.id,
+      target: { kind: 'service', did: serviceDid },
+      operation_id: 'op-group-create-1',
+      content_type: 'application/json',
+    };
+    const body = {
+      group_profile: { display_name: 'Demo' },
+      group_policy: {
+        admission_mode: 'open-join',
+        permissions: {
+          send: 'member',
+          add: 'admin',
+          remove: 'admin',
+          update_profile: 'admin',
+          update_policy: 'owner',
+        },
+      },
+    };
+    const proof = generateRfc9421OriginProof(
+      'group.create',
+      meta,
+      body,
+      bundle.keys['key-1'].privateKeyPem,
+      `${bundle.didDocument.id}#key-1`,
+      { created: 1712000100, nonce: 'nonce-group-create' }
+    );
+    const result = verifyRfc9421OriginProof(proof, 'group.create', meta, body, {
+      didDocument: bundle.didDocument,
+      options: { expectedSignerDid: bundle.didDocument.id },
+    });
+    expect(result.parsedSignatureInput.nonce).toBe('nonce-group-create');
+  });
+
+  test('rejects a non-sig1 label', () => {
+    const bundle = createDidDocument('example.com', {
+      pathSegments: ['user', 'alice'],
+      didProfile: DidProfile.E1,
+      enableE2ee: false,
+    });
+    expect(() =>
+      generateRfc9421OriginProof(
+        'direct.send',
+        { ...DIRECT_META, sender_did: bundle.didDocument.id },
+        { text: 'hello' },
+        bundle.keys['key-1'].privateKeyPem,
+        `${bundle.didDocument.id}#key-1`,
+        { label: 'sig2' }
+      )
+    ).toThrow(Rfc9421OriginProofError);
+    expect(() =>
+      generateRfc9421OriginProof(
+        'direct.send',
+        { ...DIRECT_META, sender_did: bundle.didDocument.id },
+        { text: 'hello' },
+        bundle.keys['key-1'].privateKeyPem,
+        `${bundle.didDocument.id}#key-1`,
+        { label: 'sig2' }
+      )
+    ).toThrow(/signature label sig1/);
+  });
+
+  test('rejects signature input with an extra covered component', () => {
+    const bundle = createDidDocument('example.com', {
+      pathSegments: ['user', 'alice'],
+      didProfile: DidProfile.E1,
+      enableE2ee: false,
+    });
+    const meta = { ...DIRECT_META, sender_did: bundle.didDocument.id };
+    const body = { text: 'hello' };
+    const proof = generateRfc9421OriginProof(
+      'direct.send',
+      meta,
+      body,
+      bundle.keys['key-1'].privateKeyPem,
+      `${bundle.didDocument.id}#key-1`,
+      { created: 1712000200, nonce: 'nonce-extra-component' }
+    );
+    const tampered = {
+      ...proof,
+      signatureInput: proof.signatureInput.replace(
+        '("@method" "@target-uri" "content-digest")',
+        '("@method" "@target-uri" "content-digest" "@authority")'
+      ),
+    };
+    expect(() =>
+      verifyRfc9421OriginProof(tampered, 'direct.send', meta, body, {
+        didDocument: bundle.didDocument,
+        options: { expectedSignerDid: bundle.didDocument.id },
+      })
+    ).toThrow(/covered components/);
+  });
+});


### PR DESCRIPTION
## Summary

- allow a removed MLS device to replace its inactive local group when an owner-controlled re-add delivers a fresh KeyPackage and Welcome
- add TypeScript Device Manifest parsing, validation, DID document build/update/remove helpers, and public API exports
- add RFC 9421 origin-proof generation and verification with strict sig1 covered-component validation
- add shared-vector and regression coverage for all new behavior

## Compatibility and risk

- DID documents without a deviceManifest remain valid and return null from manifest lookup
- existing active MLS bindings do not use the replace-old-group path
- no existing public API is removed
- the main security-sensitive paths validate DID key ownership and relationships, reject private key material, and pin the origin-proof label and covered components

## Verification

- cargo fmt --all --check
- cargo test --test group_e2ee_v2_operations: 12 passed
- npm ci
- npm run typecheck
- npm run build: ESM, CJS, and DTS passed
- npm test: 10 files, 92 tests passed
- eslint on the four new TypeScript source/test files: passed

## Existing lint debt

The full TypeScript lint command still reports existing formatting and require-await findings in pre-existing tracked files. This PR formats the four newly added files without reformatting unrelated code.